### PR TITLE
Update desktop Homepage to include production toggle in settings

### DIFF
--- a/src/Components/Header.tsx
+++ b/src/Components/Header.tsx
@@ -1,4 +1,4 @@
-import { useNavigate, useLocation } from 'react-router-dom';
+import { useNavigate, useLocation, useSearchParams } from 'react-router-dom';
 import {useWalletLogin, useWalletMode} from '../Hooks/useWallet';
 import Modal from './Modal';
 
@@ -11,10 +11,12 @@ function Header(props: Props) {
   const { handleLogout, claims } = props;
   const handleWalletLogin = useWalletLogin();
 
+  const [searchParams] = useSearchParams();
+  const isProduction = searchParams.get('environment') === 'production';
   const location = useLocation();
   const navigate = useNavigate();
   const walletMode = useWalletMode();
-  const handleLogin = walletMode ? () => handleWalletLogin() : () => navigate('/login');
+  const handleLogin = walletMode ? () => handleWalletLogin() : () => navigate(isProduction ? '/login?environment=production' : '/login');
 
   let mql = window.matchMedia('(min-width: 1024px)');
 
@@ -24,7 +26,7 @@ function Header(props: Props) {
         window.location.pathname.includes('dashboard') ? 'dashboard-header' : ''
       }`}
     >
-      <a href={walletMode ? "/?wallet=true" : "/"}>
+      <a href={`${walletMode ? "/?wallet=true" : "/"}${isProduction ? '&environment=production' : ''}`}>
         <div className="logo-group flex flex-grow-0">
           <img
             src="/logo-text.png"

--- a/src/Components/Modal.tsx
+++ b/src/Components/Modal.tsx
@@ -149,7 +149,7 @@ export default function Modal() {
                     );
                   })}
                 </div>
-              )};
+              )}
             </DialogBody>
           </Dialog>
         </>

--- a/src/Components/Modal.tsx
+++ b/src/Components/Modal.tsx
@@ -16,7 +16,6 @@ export default function Modal() {
   const environment = searchParams.get('environment') ?? 'test';
 
   const qr = searchParams.get('qr');
-  let mql = window.matchMedia('(min-width: 1024px)');
 
   const enabledCountries = countries.filter(
     (country) => searchParams.get(country) !== null
@@ -81,7 +80,7 @@ export default function Modal() {
 
   return (
     <Fragment>
-      {location.pathname === '/login' ? (
+      {location.pathname === '/' || '/login' ? (
         <>
           <Button
             onClick={handleOpen}
@@ -109,7 +108,7 @@ export default function Modal() {
                     onChange={handleToggleEnv}
                   />
                 </div>
-                {!isMobile && (
+                {!isMobile && location.pathname === '/login' && (
                   <div className="m-2">
                     <Switch
                       id="qr-toggle"
@@ -130,38 +129,30 @@ export default function Modal() {
                   />
                 </div>
               </div>
-              <div className="checkbox-wrapper flex flex-col m-2">
-                {countries.map((country) => {
-                  const countryName = country.charAt(0).toUpperCase() + country.slice(1);
-                  return (
-                    <label
-                      className="m-2 font-semibold text-darkText h-6 text-l"
-                      key={country}
-                    >
-                      <input
-                        type="checkbox"
-                        className={`w-5 ${walletMode ? 'bg-gray-200 cursor-not-allowed opacity-50' : ''}`}
-                        checked={enabledCountries.includes(country)}
-                        onChange={() => {
-                          handleCountry(country);
-                        }}
-                      />
-                      <span className={`pl-2 pb-4 ${walletMode ? 'opacity-50' : ''}`}>{countryName}</span>
-                    </label>
-                  );
-                })}
-              </div>
+              {location.pathname === '/login' && (
+                <div className="checkbox-wrapper flex flex-col m-2">
+                  {countries.map((country) => {
+                    const countryName = country.charAt(0).toUpperCase() + country.slice(1);
+                    return (
+                      <label className="m-2 font-semibold text-darkText h-6 text-l" key={country}>
+                        <input
+                          type="checkbox"
+                          className={`w-5 ${walletMode ? 'bg-gray-200 cursor-not-allowed opacity-50' : ''}`}
+                          checked={enabledCountries.includes(country)}
+                          onChange={() => {
+                            handleCountry(country);
+                          }}
+                          disabled={walletMode}
+                        />
+                        <span className={`pl-2 pb-4 ${walletMode ? 'opacity-50' : ''}`}>{countryName}</span>
+                      </label>
+                    );
+                  })}
+                </div>
+              )};
             </DialogBody>
           </Dialog>
         </>
-      ) : location.pathname === '/' && mql.matches ? (
-        <Switch
-          id="wallet-toggle"
-          color="indigo"
-          checked={walletMode} 
-          onChange={handleWalletToggle}
-          label={<span className="text-primary font-semibold cursor-pointer">Wallet mode</span>}
-        />
       ) : null}
     </Fragment>
   );


### PR DESCRIPTION
- The Homepage route (`'/'`) for large screens is updated to include the modal-opening-gear-icon rather than wallet-mode-toggle only. It's only possible to switch between environments and toggle wallet mode from Homepage on desktop. 
- When navigating from Homepage to `/login` on desktop, both environment and wallet mode parameters are preserved. 
- Header logo link is updated to also carry both parameters.