### PR TITLE
Add QR code to Homepage

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -103,9 +103,11 @@
   font-weight: 500;
   padding-top: 3rem;
   padding-bottom: 0.1rem;
+  background-color: #ededfb;
 }
 
 .qrBox p {
   padding-bottom: 0.5rem;
   font-size: 0.9rem;
+  background-color: #ededfb;
 }

--- a/src/Components/HomeDesktop.tsx
+++ b/src/Components/HomeDesktop.tsx
@@ -1,4 +1,16 @@
+import React from 'react';
+import { QRCode } from '@criipto/verify-react';
+import { useWalletMode } from '../Hooks/useWallet';
+
 function Home() {
+  const walletMode = useWalletMode();
+
+  function shouldShowQr(): boolean {
+    const searchParams = new URLSearchParams(window.location.search);
+    return searchParams.has('qr');
+  }
+  const showQr = shouldShowQr();
+
   const newsContent =
     'Lorem ipsum dolor sit amet consectetur. Nam aenean cursus placerat habitasse duis massa id sagittis curabitur. Dapibus sed auctor sed lectus erat nec quam.';
 
@@ -6,10 +18,75 @@ function Home() {
 
   return (
     <>
-      <div className="flex items-top justify-start mt-4 bg-contain bg-hero bg-center bg-no-repeat h-60 h-96">
-        <h1 className="text-5xl font-medium mt-16 w-[868px] ml-10 leading-[60px]">
-          Cool Energy named one of the world's most sustainable energy companies
-        </h1>
+      <div className="flex items-top justify-between mt-4 bg-contain bg-hero bg-center bg-no-repeat h-60 h-96">
+          <h1 className="text-5xl font-medium mt-16 w-[868px] ml-10 leading-[60px]">
+            Cool Energy named one of the world's most sustainable energy companies
+          </h1>
+          {showQr && walletMode && (
+            <div className="qrBox">
+              <QRCode margin={3} acrValues={['urn:authn:vc:danish_identity']}>
+                {({ qrElement, isAcknowledged, isEnabled, isCancelled, retry, error }) => (
+                  <React.Fragment>
+                    <React.Fragment>
+                      {isEnabled === false ? (
+                        <React.Fragment>
+                          <h2>An error occurred</h2>
+                          <p>
+                            QR codes are not enabled for this application. Please go to{' '}
+                            <a
+                              href="https://dashboard.criipto.com"
+                              target="_blank"
+                              rel="noreferrer"
+                              className="text-primary hover:text-darkText underline"
+                            >
+                              your Criipto dashboard
+                            </a>{' '}
+                            to activate QR codes.
+                          </p>
+                        </React.Fragment>
+                      ) : error ? (
+                        <React.Fragment>
+                          <h2>An error occurred</h2>
+                          <p>
+                            {error.message ?? error}
+                            <br />
+                            <button onClick={retry}>Try again.</button>
+                            <br />
+                          </p>
+                        </React.Fragment>
+                      ) : isCancelled ? (
+                        <React.Fragment>
+                          <h2>Login cancelled</h2>
+                          <p>
+                            <button
+                              onClick={retry}
+                              className="text-primary hover:text-darkText underline"
+                            >
+                              Try again.
+                            </button>
+                            <br />
+                          </p>
+                        </React.Fragment>
+                      ) : isAcknowledged ? (
+                        <React.Fragment>
+                          <h2>Pending</h2>
+                          <p>Complete the login process on your phone</p>
+                        </React.Fragment>
+                      ) : (
+                        <React.Fragment>
+                          <h2>Login with the QR code</h2>
+                          <p>using the camera app on your phone</p>
+                          <div className="flex items-center justify-center">
+                            <div className="w-64">{qrElement}</div>
+                          </div>
+                        </React.Fragment>
+                      )}
+                    </React.Fragment>
+                  </React.Fragment>
+                )}
+              </QRCode>
+            </div>
+          )}
       </div>
       <div className="flex mb-4 justify-center align-center content-start">
         {newsHeadings.map((heading) => (

--- a/src/Components/Modal.tsx
+++ b/src/Components/Modal.tsx
@@ -57,9 +57,17 @@ export default function Modal() {
     setSearchParams((params) => {
       if (walletMode) {
         params.delete('wallet');
+        // Delete qr params when wallet mode is enabled on homepage
+        if (location.pathname === '/' ){
+          params.delete('qr');
+        } 
       } else {
         params.set('wallet', 'true');
       }
+      // Clear selected countries when walletMode is enabled
+      enabledCountries.forEach((country) => {
+        params.delete(country);
+      });
       return params;
     });
   };
@@ -108,17 +116,6 @@ export default function Modal() {
                     onChange={handleToggleEnv}
                   />
                 </div>
-                {!isMobile && location.pathname === '/login' && (
-                  <div className="m-2">
-                    <Switch
-                      id="qr-toggle"
-                      label="QR code"
-                      color="indigo"
-                      checked={qr === 'true'}
-                      onChange={handleToggleQr}
-                    />
-                  </div>
-                )}
                 <div className="m-2">
                   <Switch 
                     id="wallet-toggle" 
@@ -128,6 +125,18 @@ export default function Modal() {
                     onChange={handleWalletToggle} 
                   />
                 </div>
+                {!isMobile && ((location.pathname === '/login') || (location.pathname === '/' && walletMode)) && (
+                  <div className="m-2">
+                    <Switch
+                      id="qr-toggle"
+                      label="QR code"
+                      color="indigo"
+                      checked={qr === 'true'}
+                      onChange={location.pathname === '/login' || (location.pathname === '/' && walletMode) ? handleToggleQr : undefined}
+                      disabled={location.pathname === '/' && !walletMode}
+                    />
+                  </div>
+                )}
               </div>
               {location.pathname === '/login' && (
                 <div className="checkbox-wrapper flex flex-col m-2">


### PR DESCRIPTION
- Add an option to render QR code on Homepage (only in wallet mode)
- On the `/login` page, clear countries selection when wallet mode is enabled